### PR TITLE
Add changes in peer dependencies for RN 64+

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "@types/react-native": ">=0.60.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "*",
     "react-native": ">=0.59.0"
   },
   "scripts": {}


### PR DESCRIPTION
Since version 64 of react-native, the react version is set to 17 and we have versions mismatch when use react-native-scalable-image. So change react peer dependency and remove prop-types peer dependency